### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Authors@R:
     person(given = "Joe",
            family = "Thorley",
            role = c("aut", "cre"),
-           email = "joe@poissonconsulting.ca")
+           email = "joe@poissonconsulting.ca",
+           comment = c(ORCID = "0000-0002-7683-4592"))
 Description: Manipulates Monte Carlo Markov Chain samples and associated
     data frames.
 License: MIT + file LICENSE


### PR DESCRIPTION
Add Joe Thorley's ORCID (0000-0002-7683-4592).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)